### PR TITLE
test: introduce testify/assert

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env bash
 
-compile() {
+clean() {
+  go clean --cache
+}
+
+format() {
   go fmt ./...
+}
+
+compile() {
   go vet ./...
   go build ./...
 }
@@ -11,8 +18,6 @@ test() {
 }
 
 cover() {
-  #go test -cover ./...
-
   mkdir -p coverage
   go test -coverprofile=coverage/cover.out ./...
   go tool cover -html=coverage/cover.out -o coverage/cover.html
@@ -28,21 +33,41 @@ bench() {
   popd
 }
 
-case $1 in
-test)
-  test
-  ;;
-cover)
-  cover
-  ;;
-bench)
-  bench
-  ;;
-'')
+if [[ $# == 0 ]]; then
+  clean
+  format
   compile
-  ;;
-*)
-  echo "Bad task: $1"
-  exit 1
-  ;;
-esac
+  test
+  cover
+  exit 0
+fi
+
+for a in "$@"; do
+  case "$a" in
+  clean)
+    clean
+    ;;
+  format)
+    format
+    ;;
+  compile)
+    compile
+    ;;
+  test)
+    test
+    ;;
+  cover)
+    cover
+    ;;
+  bench)
+    bench
+    ;;
+  '')
+    compile
+    ;;
+  *)
+    echo "Bad task: $a"
+    exit 1
+    ;;
+  esac
+done

--- a/configuration_test.go
+++ b/configuration_test.go
@@ -2,6 +2,7 @@ package reasonederror
 
 import (
 	"container/list"
+	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
 	"time"
@@ -21,12 +22,8 @@ func TestAddSyncHandler_zeroHandler(t *testing.T) {
 	clearHandlers()
 	defer clearHandlers()
 
-	if syncHandlers.head != nil {
-		t.Errorf("syncHandlers.head should be nil but: %v.\n", syncHandlers.head)
-	}
-	if syncHandlers.last != nil {
-		t.Errorf("syncHandlers.last should be nil but: %v.\n", syncHandlers.last)
-	}
+	assert.Nil(t, syncHandlers.head)
+	assert.Nil(t, syncHandlers.last)
 }
 
 func TestAddSyncHandler_oneHandler(t *testing.T) {
@@ -35,23 +32,14 @@ func TestAddSyncHandler_oneHandler(t *testing.T) {
 
 	AddSyncHandler(func(re ReasonedError, dttm time.Time) {})
 
-	if syncHandlers.head == nil {
-		t.Errorf("syncHandlers.head should not be nil.\n")
-	}
-	if syncHandlers.head != syncHandlers.last {
-		t.Errorf("syncHandlers.head should be equal to .last.\n")
-	}
-	if syncHandlers.head.handler == nil {
-		t.Errorf("syncHandlers.head.handler should not be nil.\n")
-	}
+	assert.NotNil(t, syncHandlers.head)
+	assert.Equal(t, syncHandlers.head, syncHandlers.last)
+	assert.NotNil(t, syncHandlers.head.handler)
 
 	typ := reflect.TypeOf(syncHandlers.head.handler)
-	if typ.String() != "func(reasonederror.ReasonedError, time.Time)" {
-		t.Errorf("Type of syncHandlers.head.handler: %v.\n", typ)
-	}
-	if syncHandlers.last.next != nil {
-		t.Errorf("syncHandlers.last.next should be nil: %v.\n", syncHandlers.head.next)
-	}
+	assert.Equal(t, typ.String(), "func(reasonederror.ReasonedError, time.Time)")
+
+	assert.Nil(t, syncHandlers.last.next)
 }
 
 func TestAddSyncHandler_twoHandlers(t *testing.T) {
@@ -61,45 +49,27 @@ func TestAddSyncHandler_twoHandlers(t *testing.T) {
 	AddSyncHandler(func(re ReasonedError, dttm time.Time) {})
 	AddSyncHandler(func(re ReasonedError, dttm time.Time) {})
 
-	if syncHandlers.head == nil {
-		t.Errorf("syncHandlers.head should not be nil.\n")
-	}
-	if syncHandlers.head.next != syncHandlers.last {
-		t.Errorf("syncHandlers.head.next should be equal to .last.\n")
-	}
-	if syncHandlers.head.handler == nil {
-		t.Errorf("syncHandlers.head.handler should not be nil.\n")
-	}
+	assert.NotNil(t, syncHandlers.head)
+	assert.NotEqual(t, syncHandlers.head, syncHandlers.last)
+	assert.NotNil(t, syncHandlers.head.handler)
 
 	typ := reflect.TypeOf(syncHandlers.head.handler)
-	if typ.String() != "func(reasonederror.ReasonedError, time.Time)" {
-		t.Errorf("Type of syncHandlers.head.handler: %v.\n", typ)
-	}
+	assert.Equal(t, typ.String(), "func(reasonederror.ReasonedError, time.Time)")
 
-	if syncHandlers.head.next.handler == nil {
-		t.Errorf("syncHandlers.head.next.handler should not be nil.\n")
-	}
+	assert.NotNil(t, syncHandlers.head.next)
 
 	typ = reflect.TypeOf(syncHandlers.head.next.handler)
-	if typ.String() != "func(reasonederror.ReasonedError, time.Time)" {
-		t.Errorf("Type of syncHandlers.head.next.handler: %v.\n", typ)
-	}
+	assert.Equal(t, typ.String(), "func(reasonederror.ReasonedError, time.Time)")
 
-	if syncHandlers.last.next != nil {
-		t.Errorf("syncHandlers.last.next should be nil: %v.\n", syncHandlers.head.next)
-	}
+	assert.Nil(t, syncHandlers.last.next)
 }
 
 func TestAddAsyncHandler_zeroHandler(t *testing.T) {
 	clearHandlers()
 	defer clearHandlers()
 
-	if asyncHandlers.head != nil {
-		t.Errorf("asyncHandlers.head should be nil but: %v.\n", asyncHandlers.head)
-	}
-	if asyncHandlers.last != nil {
-		t.Errorf("asyncHandlers.last should be nil but: %v.\n", asyncHandlers.last)
-	}
+	assert.Nil(t, asyncHandlers.head)
+	assert.Nil(t, asyncHandlers.last)
 }
 
 func TestAddAsyncHandler_oneHandler(t *testing.T) {
@@ -108,24 +78,14 @@ func TestAddAsyncHandler_oneHandler(t *testing.T) {
 
 	AddAsyncHandler(func(re ReasonedError, dttm time.Time) {})
 
-	if asyncHandlers.head == nil {
-		t.Errorf("asyncHandlers.head should not be nil.\n")
-	}
-	if asyncHandlers.head != asyncHandlers.last {
-		t.Errorf("asyncHandlers.head should be equal to .last.\n")
-	}
-	if asyncHandlers.head.handler == nil {
-		t.Errorf("asyncHandlers.head.handler should not be nil.\n")
-	}
+	assert.NotNil(t, asyncHandlers.head)
+	assert.Equal(t, asyncHandlers.head, asyncHandlers.last)
+	assert.NotNil(t, asyncHandlers.head.handler)
 
 	typ := reflect.TypeOf(asyncHandlers.head.handler)
-	if typ.String() != "func(reasonederror.ReasonedError, time.Time)" {
-		t.Errorf("Type of asyncHandlers.head.handler: %v.\n", typ)
-	}
+	assert.Equal(t, typ.String(), "func(reasonederror.ReasonedError, time.Time)")
 
-	if asyncHandlers.last.next != nil {
-		t.Errorf("asyncHandlers.last.next should be nil, but: %v.\n", asyncHandlers.last.next)
-	}
+	assert.Nil(t, asyncHandlers.last.next)
 }
 
 func TestAddAsyncHandler_twoHandlers(t *testing.T) {
@@ -135,34 +95,19 @@ func TestAddAsyncHandler_twoHandlers(t *testing.T) {
 	AddAsyncHandler(func(re ReasonedError, dttm time.Time) {})
 	AddAsyncHandler(func(re ReasonedError, dttm time.Time) {})
 
-	if asyncHandlers.head == nil {
-		t.Errorf("asyncHandlers.head should not be nil.\n")
-	}
-	if asyncHandlers.head.next != asyncHandlers.last {
-		t.Errorf("asyncHandlers.head.next should be equal to .last.\n")
-	}
-
-	if asyncHandlers.head.handler == nil {
-		t.Errorf("asyncHandlers.head.handler should not be nil.\n")
-	}
+	assert.NotNil(t, asyncHandlers.head)
+	assert.NotEqual(t, asyncHandlers.head, asyncHandlers.last)
+	assert.NotNil(t, asyncHandlers.head.handler)
 
 	typ := reflect.TypeOf(asyncHandlers.head.handler)
-	if typ.String() != "func(reasonederror.ReasonedError, time.Time)" {
-		t.Errorf("Type of asyncHandlers.head.handler: %v.\n", typ)
-	}
+	assert.Equal(t, typ.String(), "func(reasonederror.ReasonedError, time.Time)")
 
-	if asyncHandlers.head.next.handler == nil {
-		t.Errorf("asyncHandlers.head.next.handler should not be nil.\n")
-	}
+	assert.NotNil(t, asyncHandlers.head.next)
 
 	typ = reflect.TypeOf(asyncHandlers.head.next.handler)
-	if typ.String() != "func(reasonederror.ReasonedError, time.Time)" {
-		t.Errorf("Type of asyncHandlers.head.next.handler: %v.\n", typ)
-	}
+	assert.Equal(t, typ.String(), "func(reasonederror.ReasonedError, time.Time)")
 
-	if asyncHandlers.last.next != nil {
-		t.Errorf("asyncHandlers.last.next should be nil: %v.\n", asyncHandlers.head.next)
-	}
+	assert.Nil(t, asyncHandlers.last.next)
 }
 
 func TestFixConfiguration(t *testing.T) {
@@ -172,86 +117,46 @@ func TestFixConfiguration(t *testing.T) {
 	AddSyncHandler(func(re ReasonedError, dttm time.Time) {})
 	AddAsyncHandler(func(re ReasonedError, dttm time.Time) {})
 
-	if syncHandlers.head == nil {
-		t.Errorf("syncHandlers.head should not be nil.\n")
-	}
-	if syncHandlers.head != syncHandlers.last {
-		t.Errorf("syncHandlers.head should be equal to .last.\n")
-	}
-	if syncHandlers.head.handler == nil {
-		t.Errorf("syncHandlers.head.handler should not be nil.\n")
-	}
+	assert.NotNil(t, syncHandlers.head)
+	assert.NotNil(t, syncHandlers.head, syncHandlers.last)
+	assert.NotNil(t, syncHandlers.head.handler)
 
 	typ := reflect.TypeOf(syncHandlers.head.handler)
-	if typ.String() != "func(reasonederror.ReasonedError, time.Time)" {
-		t.Errorf("Type of syncHandlers.head.handler: %v.\n", typ)
-	}
+	assert.Equal(t, typ.String(), "func(reasonederror.ReasonedError, time.Time)")
 
-	if syncHandlers.last.next != nil {
-		t.Errorf("syncHandlers.last.next should be nil: %v.\n", syncHandlers.head.next)
-	}
+	assert.Nil(t, syncHandlers.last.next)
 
-	if asyncHandlers.head == nil {
-		t.Errorf("asyncHandlers.head should not be nil.\n")
-	}
-	if asyncHandlers.head != asyncHandlers.last {
-		t.Errorf("asyncHandlers.head should be equal to .last.\n")
-	}
-	if asyncHandlers.head.handler == nil {
-		t.Errorf("asyncHandlers.head.handler should not be nil.\n")
-	}
+	assert.NotNil(t, asyncHandlers.head)
+	assert.NotNil(t, asyncHandlers.head, asyncHandlers.last)
+	assert.NotNil(t, asyncHandlers.head.handler)
 
 	typ = reflect.TypeOf(asyncHandlers.head.handler)
-	if typ.String() != "func(reasonederror.ReasonedError, time.Time)" {
-		t.Errorf("Type of asyncHandlers.head.handler: %v.\n", typ)
-	}
+	assert.Equal(t, typ.String(), "func(reasonederror.ReasonedError, time.Time)")
 
-	if asyncHandlers.last.next != nil {
-		t.Errorf("asyncHandlers.last.next should be nil: %v.\n", asyncHandlers.head.next)
-	}
+	assert.Nil(t, asyncHandlers.last.next)
 
 	FixConfiguration()
 
 	AddSyncHandler(func(re ReasonedError, dttm time.Time) {})
 	AddAsyncHandler(func(re ReasonedError, dttm time.Time) {})
 
-	if syncHandlers.head == nil {
-		t.Errorf("syncHandlers.head should not be nil.\n")
-	}
-	if syncHandlers.head != syncHandlers.last {
-		t.Errorf("syncHandlers.head should be equal to .last.\n")
-	}
-	if syncHandlers.head.handler == nil {
-		t.Errorf("syncHandlers.head.handler should not be nil.\n")
-	}
+	assert.NotNil(t, syncHandlers.head)
+	assert.NotNil(t, syncHandlers.head, asyncHandlers.last)
+	assert.NotNil(t, syncHandlers.head.handler)
 
 	typ = reflect.TypeOf(syncHandlers.head.handler)
-	if typ.String() != "func(reasonederror.ReasonedError, time.Time)" {
-		t.Errorf("Type of syncHandlers.head.handler: %v.\n", typ)
-	}
+	assert.Equal(t, typ.String(), "func(reasonederror.ReasonedError, time.Time)")
 
-	if syncHandlers.last.next != nil {
-		t.Errorf("syncHandlers.last.next should be nil: %v.\n", syncHandlers.head.next)
-	}
+	assert.Nil(t, syncHandlers.last.next)
 
-	if asyncHandlers.head == nil {
-		t.Errorf("asyncHandlers.head should not be nil.\n")
-	}
-	if asyncHandlers.head != asyncHandlers.last {
-		t.Errorf("asyncHandlers.head should be equal to .last.\n")
-	}
-	if asyncHandlers.head.handler == nil {
-		t.Errorf("asyncHandlers.head.handler should not be nil.\n")
-	}
+	assert.NotNil(t, asyncHandlers.head)
+	assert.NotNil(t, asyncHandlers.head, asyncHandlers.last)
+	assert.NotNil(t, asyncHandlers.head.handler)
 
 	typ = reflect.TypeOf(asyncHandlers.head.handler)
-	if typ.String() != "func(reasonederror.ReasonedError, time.Time)" {
-		t.Errorf("Type of asyncHandlers.head.handler: %v.\n", typ)
-	}
+	assert.Equal(t, typ.String(), "func(reasonederror.ReasonedError, time.Time)")
 
-	if asyncHandlers.last.next != nil {
-		t.Errorf("asyncHandlers.last.next should be nil: %v.\n", asyncHandlers.head.next)
-	}
+	assert.Nil(t, asyncHandlers.last.next)
 }
 
 func TestNotify_withNoHandler(t *testing.T) {
@@ -260,17 +165,13 @@ func TestNotify_withNoHandler(t *testing.T) {
 
 	By(FailToDoSomething{})
 
-	if isFixed {
-		t.Errorf("isFixed should be false but: %v.\n", isFixed)
-	}
+	assert.False(t, isFixed)
 
 	FixConfiguration()
 
 	By(FailToDoSomething{})
 
-	if !isFixed {
-		t.Errorf("isFixed should be true but: %v.\n", isFixed)
-	}
+	assert.True(t, isFixed)
 }
 
 func TestNotify_withHandlers(t *testing.T) {
@@ -292,39 +193,21 @@ func TestNotify_withHandlers(t *testing.T) {
 
 	By(FailToDoSomething{})
 
-	if isFixed {
-		t.Errorf("isFixed should be false but: %v.\n", isFixed)
-	}
-	if syncLogs.Len() != 0 {
-		t.Errorf("The size of syncLogs should be zero because not calling FixConfiguration.\n")
-	}
-	if asyncLogs.Len() != 0 {
-		t.Errorf("The size of asyncLogs should be zero because not calling FixConfiguration.\n")
-	}
+	assert.False(t, isFixed)
+	assert.Equal(t, syncLogs.Len(), 0)
+	assert.Equal(t, asyncLogs.Len(), 0)
 
 	FixConfiguration()
 
 	By(FailToDoSomething{})
 
-	if !isFixed {
-		t.Errorf("isFixed should be true but: %v.\n", isFixed)
-	}
-	if syncLogs.Len() != 2 {
-		t.Errorf("The size of syncLogs should be 2 but: %v.\n", syncLogs.Len())
-	}
-	if syncLogs.Front().Value != "FailToDoSomething-1" {
-		t.Errorf("syncLogs[0]=%v.\n", syncLogs.Front().Value)
-	}
-	if syncLogs.Front().Next().Value != "FailToDoSomething-2" {
-		t.Errorf("syncLogs[1]=%v.\n", syncLogs.Front().Next().Value)
-	}
+	assert.True(t, isFixed)
+	assert.Equal(t, syncLogs.Len(), 2)
+	assert.Equal(t, syncLogs.Front().Value, "FailToDoSomething-1")
+	assert.Equal(t, syncLogs.Front().Next().Value, "FailToDoSomething-2")
 
 	time.Sleep(100 * time.Millisecond)
 
-	if asyncLogs.Len() != 1 {
-		t.Errorf("The size of asyncLogs should be 1 but: %v.\n", asyncLogs.Len())
-	}
-	if asyncLogs.Front().Value != "FailToDoSomething-3" {
-		t.Errorf("asyncLogs[0]=%v.\n", asyncLogs.Front().Value)
-	}
+	assert.Equal(t, asyncLogs.Len(), 1)
+	assert.Equal(t, asyncLogs.Front().Value, "FailToDoSomething-3")
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/sttk-go/reasonederror
 
 go 1.13
+
+require github.com/stretchr/testify v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,15 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/reasoned-error_test.go
+++ b/reasoned-error_test.go
@@ -1,6 +1,7 @@
 package reasonederror_test
 
 import (
+	"github.com/stretchr/testify/assert"
 	"github.com/sttk-go/reasonederror"
 	"testing"
 )
@@ -14,22 +15,9 @@ type /* Error */ (
 func TestBy_reasonIsValue(t *testing.T) {
 	re := reasonederror.By(InvalidValue{Value: "abc"})
 
-	// t.Logf("re = %v\n", re)
-
-	ex0 := "reason=InvalidValue, Value=abc"
-	if re.Error() != ex0 {
-		t.Errorf("re.Error() = %v (differ from %v)\n", re.Error(), ex0)
-	}
-
-	ex1 := "reasoned-error_test.go"
-	if re.FileName() != ex1 {
-		t.Errorf("re.FileName() = %v (differ from %v)\n", re.FileName(), ex1)
-	}
-
-	ex2 := 15
-	if re.LineNumber() != ex2 {
-		t.Errorf("re.LineNumber() = %v (differ from %v)\n", re.LineNumber(), ex2)
-	}
+	assert.Equal(t, re.Error(), "reason=InvalidValue, Value=abc")
+	assert.Equal(t, re.FileName(), "reasoned-error_test.go")
+	assert.Equal(t, re.LineNumber(), 16)
 
 	switch re.Reason().(type) {
 	case InvalidValue:
@@ -37,47 +25,26 @@ func TestBy_reasonIsValue(t *testing.T) {
 		t.Errorf("re.Reason() = %v\n", re.Reason())
 	}
 
-	ex3 := "InvalidValue"
-	if re.ReasonName() != ex3 {
-		t.Errorf("re.ReasonName() = %v (differ from %v)\n", re.ReasonName(), ex3)
-	}
-
-	ex4 := "github.com/sttk-go/reasonederror_test"
-	if re.ReasonPackage() != ex4 {
-		t.Errorf("re.ReasonPackage() = %v (differ from %v)\n", re.ReasonPackage(), ex4)
-	}
+	assert.Equal(t, re.ReasonName(), "InvalidValue")
+	assert.Equal(t, re.ReasonPackage(), "github.com/sttk-go/reasonederror_test")
+	assert.Equal(t, re.SituationValue("Value"), "abc")
+	assert.Nil(t, re.SituationValue("value"))
 
 	m := re.Situation()
-	ex5 := 1
-	if len(m) != ex5 {
-		t.Errorf("re.Situation():len = %v (differ from %v)\n", len(m), ex5)
-	}
+	assert.Equal(t, len(m), 1)
+	assert.Equal(t, m["Value"], "abc")
+	assert.Nil(t, m["value"])
 
-	ex6 := "abc"
-	if m["Value"] != ex6 {
-		t.Errorf("re.Situation():[\"Value\"] = %v (differ from %v)\n", m["Value"], ex6)
-	}
+	assert.Nil(t, re.Cause())
+	assert.Nil(t, re.Unwrap())
 }
 
 func TestBy_reasonIsPointer(t *testing.T) {
 	re := reasonederror.By(&InvalidValue{Value: "abc"})
 
-	//t.Logf("re = %v\n", re)
-
-	ex0 := "reason=InvalidValue, Value=abc"
-	if re.Error() != ex0 {
-		t.Errorf("re.Error() = %v (differ from %v)\n", re.Error(), ex0)
-	}
-
-	ex1 := "reasoned-error_test.go"
-	if re.FileName() != ex1 {
-		t.Errorf("re.FileName() = %v (differ from %v)\n", re.FileName(), ex1)
-	}
-
-	ex2 := 63
-	if re.LineNumber() != ex2 {
-		t.Errorf("re.LineNumber() = %v (differ from %v)\n", re.LineNumber(), ex2)
-	}
+	assert.Equal(t, re.Error(), "reason=InvalidValue, Value=abc")
+	assert.Equal(t, re.FileName(), "reasoned-error_test.go")
+	assert.Equal(t, re.LineNumber(), 43)
 
 	switch re.Reason().(type) {
 	case *InvalidValue:
@@ -85,33 +52,16 @@ func TestBy_reasonIsPointer(t *testing.T) {
 		t.Errorf("re.Reason() = %v\n", re.Reason())
 	}
 
-	ex3 := "InvalidValue"
-	if re.ReasonName() != ex3 {
-		t.Errorf("re.ReasonName() = %v (differ from %v)\n", re.ReasonName(), ex3)
-	}
-
-	ex4 := "github.com/sttk-go/reasonederror_test"
-	if re.ReasonPackage() != ex4 {
-		t.Errorf("re.ReasonPackage() = %v (differ from %v)\n", re.ReasonPackage(), ex4)
-	}
+	assert.Equal(t, re.ReasonName(), "InvalidValue")
+	assert.Equal(t, re.ReasonPackage(), "github.com/sttk-go/reasonederror_test")
+	assert.Equal(t, re.SituationValue("Value"), "abc")
+	assert.Nil(t, re.SituationValue("value"))
 
 	m := re.Situation()
-	ex5 := 1
-	if len(m) != ex5 {
-		t.Errorf("re.Situation():len = %v (differ from %v)\n", len(m), ex5)
-	}
-	ex6 := "abc"
-	if m["Value"] != ex6 {
-		t.Errorf("re.Situation():[\"Value\"] = %v (differ from %v)\n", m["Value"], ex6)
-	}
+	assert.Equal(t, len(m), 1)
+	assert.Equal(t, m["Value"], "abc")
+	assert.Nil(t, m["value"])
 
-	ex7 := "abc"
-	if re.SituationValue("Value") != ex7 {
-		t.Errorf("re.SituationValue(\"Value\") = %v (differ from %v)\n", re.SituationValue("Value"), ex7)
-	}
-
-	var ex8 interface{} = nil
-	if re.SituationValue("Xxx") != ex8 {
-		t.Errorf("re.SituationValue(\"Value\") = %v (differ from %v)\n", re.SituationValue("Value"), ex8)
-	}
+	assert.Nil(t, re.Cause())
+	assert.Nil(t, re.Unwrap())
 }


### PR DESCRIPTION
### Changes

- [chore: enhanced build.sh](https://github.com/sttk-go/reasonederror/commit/e359f3cb072709e66bade482a45f4f6ecf298c7e)

    This modification adds `clean` and `format` commands, and make enable to specify multiple commands.  

- [test: introduced testify/assert](https://github.com/sttk-go/reasonederror/commit/11742075c3d0113b73e6ec08d9c5e887e3ef3819)

    This modification rewrites test code with `testify/assert`.