### PR TITLE
feat: added reasonederror.Ok, etc

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        gover: [1.13, 1.14, 1.15, 1.16, 1.17]
+        gover: [1.13, 1.14, 1.15, 1.16, 1.17, 1.18]
     steps:
     - uses: actions/checkout@v2
 

--- a/.gitmessage.txt
+++ b/.gitmessage.txt
@@ -1,0 +1,19 @@
+
+
+####### 50 characters ###########################
+## Prefix examples:
+#
+# feat: a new feature
+# fix: a bug fix
+# update: a slight change
+# merge: merge pull request
+# style: only code style changes
+# comment: only comment changes
+# refactor: code changes that do not affect the behavior
+# perf: a code change that improves performance
+# deps: bump deps used on compiling or runtime
+# test: update test files
+# cicd: update CI/CD configuration files.
+# doc: documentation only changes
+# wip: work in progress
+# chore: bump test deps, modify build files, etc

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ By defining a structure type for a reason in a package which creates its `Reason
 This function can take a value or pointer of a structure type, and can also take parameters by using fields of the structure.
 These parameters help to know a situation when an error is caused, and can get their values with `#Situation` or `#SituationValue` method.
 
+`reasonederror.Ok` is a global value of `ReasonedError`, which indicates no error.
+Since `By` function returns a `ReasondError` value, not a pointer, it is needed the way to indicate and check no error with a `ReasonedError` value. `reasonederror.Ok` just indicates it, and the method `#IsOk` can check it.
 
 ### Creation notification
 
@@ -106,6 +108,38 @@ If there is a causal error, pass it to `By` function (`ReasonedError` supports `
   }, err)
 ```
 
+To return `ReasonedError` value which indicates no error, `reasonederror.Ok` is used.
+
+```
+  return reasonederror.Ok
+```
+
+Then, there are two way to check whether a `ReasonedError` value indicates no error or not.
+One way is as follows:
+
+```
+  var re readsonederror.ReasoedError
+  re = ...
+  if re.IsOk() {
+    ...
+  } else {
+    ...
+  }
+```
+
+And another way is as follows:
+
+```
+  var re readsonederror.ReasoedError
+  re = ...
+  switch re.Reason().(type) {
+  case reasonederror.NoError, *reasonederror.NoError:
+    ...
+  default:
+    ...
+  }
+```
+
 ### Registers creation handlers
 
 By registering creation handlers with `AddSyncHandler` or `AddAsyncHandler`, these handlers are notified whenever `ReasonedError`s are created with `By` function.
@@ -135,11 +169,12 @@ This library supports Go 1.13 or later.
 
 ### Actually Checked Go versions
 
-- 1.13.15
-- 1.14.15
+- 1.18.4
+- 1.17.12
+- 1.16.15
 - 1.15.15
-- 1.16.7
-- 1.17.1
+- 1.14.15
+- 1.13.15
 
 
 <a name="license"></a>

--- a/reasoned-error.go
+++ b/reasoned-error.go
@@ -19,6 +19,12 @@ type ReasonedError struct {
 	cause  error
 }
 
+// NoError is a structure type for a reason of Ok which is a global of Err and indicates no error..
+type NoError struct{}
+
+// Ok is a globak Err value which indicates no error.
+var Ok = ReasonedError{reason: NoError{}}
+
 // By function creates a new ReasonedError with a reason by a structure and a
 // cause of this error.
 // Either a value or a pointer of a structure type is fine for a reason.
@@ -39,6 +45,16 @@ func By(reason interface{}, cause ...error) ReasonedError {
 	notify(re)
 
 	return re
+}
+
+// IsOk method determines whether an Err indicates no error.
+func (err ReasonedError) IsOk() bool {
+	switch err.reason.(type) {
+	case NoError, *NoError:
+		return true
+	default:
+		return false
+	}
 }
 
 // Reason method returns the reason structure.

--- a/reasoned-error_test.go
+++ b/reasoned-error_test.go
@@ -22,9 +22,10 @@ func TestBy_reasonIsValue(t *testing.T) {
 	switch re.Reason().(type) {
 	case InvalidValue:
 	default:
-		t.Errorf("re.Reason() = %v\n", re.Reason())
+		assert.Fail(t, re.Error())
 	}
 
+	assert.False(t, re.IsOk())
 	assert.Equal(t, re.ReasonName(), "InvalidValue")
 	assert.Equal(t, re.ReasonPackage(), "github.com/sttk-go/reasonederror_test")
 	assert.Equal(t, re.SituationValue("Value"), "abc")
@@ -44,14 +45,15 @@ func TestBy_reasonIsPointer(t *testing.T) {
 
 	assert.Equal(t, re.Error(), "reason=InvalidValue, Value=abc")
 	assert.Equal(t, re.FileName(), "reasoned-error_test.go")
-	assert.Equal(t, re.LineNumber(), 43)
+	assert.Equal(t, re.LineNumber(), 44)
 
 	switch re.Reason().(type) {
 	case *InvalidValue:
 	default:
-		t.Errorf("re.Reason() = %v\n", re.Reason())
+		assert.Fail(t, re.Error())
 	}
 
+	assert.False(t, re.IsOk())
 	assert.Equal(t, re.ReasonName(), "InvalidValue")
 	assert.Equal(t, re.ReasonPackage(), "github.com/sttk-go/reasonederror_test")
 	assert.Equal(t, re.SituationValue("Value"), "abc")
@@ -61,6 +63,32 @@ func TestBy_reasonIsPointer(t *testing.T) {
 	assert.Equal(t, len(m), 1)
 	assert.Equal(t, m["Value"], "abc")
 	assert.Nil(t, m["value"])
+
+	assert.Nil(t, re.Cause())
+	assert.Nil(t, re.Unwrap())
+}
+
+func TestOk(t *testing.T) {
+	re := reasonederror.Ok
+
+	assert.Equal(t, re.Error(), "reason=NoError")
+	assert.Equal(t, re.FileName(), "")
+	assert.Equal(t, re.LineNumber(), 0)
+
+	switch re.Reason().(type) {
+	case reasonederror.NoError:
+	default:
+		assert.Fail(t, re.Error())
+	}
+
+	assert.True(t, re.IsOk())
+	assert.Equal(t, re.ReasonName(), "NoError")
+	assert.Equal(t, re.ReasonPackage(), "github.com/sttk-go/reasonederror")
+	assert.Nil(t, re.SituationValue("Value"))
+	assert.Nil(t, re.SituationValue("value"))
+
+	m := re.Situation()
+	assert.Equal(t, len(m), 0)
 
 	assert.Nil(t, re.Cause())
 	assert.Nil(t, re.Unwrap())


### PR DESCRIPTION
### Changes

- [feat: added reasonederror.Ok](https://github.com/sttk-go/reasonederror/commit/f288617a86a10388cfb01d44cecaa3e46f22e250)

    This modification `reasonederror.Ok`, `ReasonedError#IsOk` and `reasonederror.NoError`.

- [chore: added .gitmessage.txt](https://github.com/sttk-go/reasonederror/commit/485defd27e7d6305a4a7ed1e272397f33b11a60d)

    This modification adds `.gitmessage.txt` and register it to `git config`

- [doc: added descriptions about reasonederror.Ok in README.md](https://github.com/sttk-go/reasonederror/commit/b939cf497c817b1bdb3d0efe7eb288d4a1385946)

    This modification adds descriptions about `reasonederror.Ok` to Features and Usage in `README.md`

-  [cicd: added go1.18 to ci target versions](https://github.com/sttk-go/reasonederror/commit/9ff47d1399b5937a1da5de5a76fcad7ade199818)

    This modification adds go version 1.18 to matrix in `.github/workflow/go.yml`
