### PR TITLE
feat: process #Situation and #SituationValue hierarchically, etc.

### DIFF
--- a/example_reasoned-error_test.go
+++ b/example_reasoned-error_test.go
@@ -40,10 +40,10 @@ func ExampleBy() {
 	fmt.Printf("(4) %v\n", re)
 
 	// Output:
-	// (1) reason=FailToDoSomething
-	// (2) reason=FailToDoSomethingWithParams, Param1=ABC, Param2=123
-	// (3) reason=FailToDoSomething, cause=Causal error
-	// (4) reason=FailToDoSomethingWithParams, Param1=ABC, Param2=123, cause=Causal error
+	// (1) {reason=FailToDoSomething}
+	// (2) {reason=FailToDoSomethingWithParams, Param1=ABC, Param2=123}
+	// (3) {reason=FailToDoSomething, cause=Causal error}
+	// (4) {reason=FailToDoSomethingWithParams, Param1=ABC, Param2=123, cause=Causal error}
 }
 
 func ExampleReasonedError_Cause() {
@@ -73,7 +73,7 @@ func ExampleReasonedError_Error() {
 	fmt.Printf("%v\n", re.Error())
 
 	// Output:
-	// reason=FailToDoSomething, Param1=ABC, Param2=123, cause=Causal error
+	// {reason=FailToDoSomething, Param1=ABC, Param2=123, cause=Causal error}
 }
 
 func ExampleReasonedError_FileName() {

--- a/reasoned-error.go
+++ b/reasoned-error.go
@@ -180,7 +180,7 @@ func (re ReasonedError) Error() string {
 
 	t := v.Type()
 
-	s := "reason=" + t.Name()
+	s := "{reason=" + t.Name()
 
 	n := v.NumField()
 	for i := 0; i < n; i++ {
@@ -196,6 +196,7 @@ func (re ReasonedError) Error() string {
 		s += ", cause=" + re.cause.Error()
 	}
 
+	s += "}"
 	return s
 }
 

--- a/reasoned-error.go
+++ b/reasoned-error.go
@@ -19,7 +19,8 @@ type ReasonedError struct {
 	cause  error
 }
 
-// NoError is a structure type for a reason of Ok which is a global of Err and indicates no error..
+// NoError is a structure type for a reason of Ok which is a global of Err and
+// indicates no error.
 type NoError struct{}
 
 // Ok is a globak Err value which indicates no error.
@@ -84,13 +85,30 @@ func (re ReasonedError) ReasonPackage() string {
 
 // Situation method returns a map containing parameters which represent the
 // situation when this error is caused.
+// If a .cause is set and it is an ReasonedError, a returned map containes
+// parameters of .cause hierarchically.
 func (re ReasonedError) Situation() map[string]interface{} {
 	v := reflect.ValueOf(re.reason)
 	if v.Kind() == reflect.Ptr {
 		v = v.Elem()
 	}
 
-	m := map[string]interface{}{}
+	var m map[string]interface{}
+
+	if re.cause != nil {
+		t := reflect.TypeOf(re.cause)
+		_, ok := t.MethodByName("Reason")
+		if ok {
+			_, ok := t.MethodByName("Situation")
+			if ok {
+				m = re.cause.(ReasonedError).Situation()
+			}
+		}
+	}
+
+	if m == nil {
+		m = make(map[string]interface{})
+	}
 
 	t := v.Type()
 	n := v.NumField()
@@ -109,20 +127,26 @@ func (re ReasonedError) Situation() map[string]interface{} {
 
 // Situation method returns a parameter value of a specified name, which
 // represents the situation when this error is caused.
+// If a .cause is set and it is an ReasonedError, this method digs to find
+// a parameter having a same name hierarchically.
 func (re ReasonedError) SituationValue(name string) interface{} {
 	v := reflect.ValueOf(re.reason)
 	if v.Kind() == reflect.Ptr {
 		v = v.Elem()
 	}
 
-	t := v.Type()
-	n := v.NumField()
-	for i := 0; i < n; i++ {
-		k := t.Field(i).Name
-		if k == name {
-			f := v.Field(i)
-			if f.CanInterface() {
-				return f.Interface()
+	f := v.FieldByName(name)
+	if f.IsValid() && f.CanInterface() {
+		return f.Interface()
+	}
+
+	if re.cause != nil {
+		t := reflect.TypeOf(re.cause)
+		_, ok := t.MethodByName("Reason")
+		if ok {
+			_, ok := t.MethodByName("SituationValue")
+			if ok {
+				return re.cause.(ReasonedError).SituationValue(name)
 			}
 		}
 	}

--- a/reasoned-error_test.go
+++ b/reasoned-error_test.go
@@ -1,6 +1,7 @@
 package reasonederror_test
 
 import (
+	"errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/sttk-go/reasonederror"
 	"testing"
@@ -10,6 +11,9 @@ type /* Error */ (
 	InvalidValue struct {
 		Value string
 	}
+	FailToGetValue struct {
+		Name string
+	}
 )
 
 func TestBy_reasonIsValue(t *testing.T) {
@@ -17,7 +21,7 @@ func TestBy_reasonIsValue(t *testing.T) {
 
 	assert.Equal(t, re.Error(), "reason=InvalidValue, Value=abc")
 	assert.Equal(t, re.FileName(), "reasoned-error_test.go")
-	assert.Equal(t, re.LineNumber(), 16)
+	assert.Equal(t, re.LineNumber(), 20)
 
 	switch re.Reason().(type) {
 	case InvalidValue:
@@ -45,7 +49,7 @@ func TestBy_reasonIsPointer(t *testing.T) {
 
 	assert.Equal(t, re.Error(), "reason=InvalidValue, Value=abc")
 	assert.Equal(t, re.FileName(), "reasoned-error_test.go")
-	assert.Equal(t, re.LineNumber(), 44)
+	assert.Equal(t, re.LineNumber(), 48)
 
 	switch re.Reason().(type) {
 	case *InvalidValue:
@@ -66,6 +70,68 @@ func TestBy_reasonIsPointer(t *testing.T) {
 
 	assert.Nil(t, re.Cause())
 	assert.Nil(t, re.Unwrap())
+}
+
+func TestBy_withCause(t *testing.T) {
+	cause := errors.New("def")
+	re := reasonederror.By(InvalidValue{Value: "abc"}, cause)
+
+	assert.Equal(t, re.Error(), "reason=InvalidValue, Value=abc, cause=def")
+	assert.Equal(t, re.FileName(), "reasoned-error_test.go")
+	assert.Equal(t, re.LineNumber(), 77)
+
+	switch re.Reason().(type) {
+	case InvalidValue:
+	default:
+		assert.Fail(t, re.Error())
+	}
+
+	assert.False(t, re.IsOk())
+	assert.Equal(t, re.ReasonName(), "InvalidValue")
+	assert.Equal(t, re.ReasonPackage(), "github.com/sttk-go/reasonederror_test")
+	assert.Equal(t, re.SituationValue("Value"), "abc")
+	assert.Nil(t, re.SituationValue("value"))
+
+	m := re.Situation()
+	assert.Equal(t, len(m), 1)
+	assert.Equal(t, m["Value"], "abc")
+	assert.Nil(t, m["value"])
+
+	assert.Equal(t, re.Cause(), cause)
+	assert.Equal(t, re.Unwrap(), cause)
+	assert.Equal(t, errors.Unwrap(re), cause)
+}
+
+func TestBy_causeIsAlsoReasonedError(t *testing.T) {
+	cause := reasonederror.By(FailToGetValue{Name: "foo"})
+	re := reasonederror.By(InvalidValue{Value: "abc"}, cause)
+
+	assert.Equal(t, re.Error(), "reason=InvalidValue, Value=abc, cause=reason=FailToGetValue, Name=foo")
+	assert.Equal(t, re.FileName(), "reasoned-error_test.go")
+	assert.Equal(t, re.LineNumber(), 107)
+
+	switch re.Reason().(type) {
+	case InvalidValue:
+	default:
+		assert.Fail(t, re.Error())
+	}
+
+	assert.False(t, re.IsOk())
+	assert.Equal(t, re.ReasonName(), "InvalidValue")
+	assert.Equal(t, re.ReasonPackage(), "github.com/sttk-go/reasonederror_test")
+	assert.Equal(t, re.SituationValue("Value"), "abc")
+	assert.Equal(t, re.SituationValue("Name"), "foo")
+	assert.Nil(t, re.SituationValue("value"))
+
+	m := re.Situation()
+	assert.Equal(t, len(m), 2)
+	assert.Equal(t, m["Value"], "abc")
+	assert.Equal(t, m["Name"], "foo")
+	assert.Nil(t, m["value"])
+
+	assert.Equal(t, re.Cause(), cause)
+	assert.Equal(t, re.Unwrap(), cause)
+	assert.Equal(t, errors.Unwrap(re), cause)
 }
 
 func TestOk(t *testing.T) {

--- a/reasoned-error_test.go
+++ b/reasoned-error_test.go
@@ -19,7 +19,7 @@ type /* Error */ (
 func TestBy_reasonIsValue(t *testing.T) {
 	re := reasonederror.By(InvalidValue{Value: "abc"})
 
-	assert.Equal(t, re.Error(), "reason=InvalidValue, Value=abc")
+	assert.Equal(t, re.Error(), "{reason=InvalidValue, Value=abc}")
 	assert.Equal(t, re.FileName(), "reasoned-error_test.go")
 	assert.Equal(t, re.LineNumber(), 20)
 
@@ -47,7 +47,7 @@ func TestBy_reasonIsValue(t *testing.T) {
 func TestBy_reasonIsPointer(t *testing.T) {
 	re := reasonederror.By(&InvalidValue{Value: "abc"})
 
-	assert.Equal(t, re.Error(), "reason=InvalidValue, Value=abc")
+	assert.Equal(t, re.Error(), "{reason=InvalidValue, Value=abc}")
 	assert.Equal(t, re.FileName(), "reasoned-error_test.go")
 	assert.Equal(t, re.LineNumber(), 48)
 
@@ -76,7 +76,7 @@ func TestBy_withCause(t *testing.T) {
 	cause := errors.New("def")
 	re := reasonederror.By(InvalidValue{Value: "abc"}, cause)
 
-	assert.Equal(t, re.Error(), "reason=InvalidValue, Value=abc, cause=def")
+	assert.Equal(t, re.Error(), "{reason=InvalidValue, Value=abc, cause=def}")
 	assert.Equal(t, re.FileName(), "reasoned-error_test.go")
 	assert.Equal(t, re.LineNumber(), 77)
 
@@ -106,7 +106,7 @@ func TestBy_causeIsAlsoReasonedError(t *testing.T) {
 	cause := reasonederror.By(FailToGetValue{Name: "foo"})
 	re := reasonederror.By(InvalidValue{Value: "abc"}, cause)
 
-	assert.Equal(t, re.Error(), "reason=InvalidValue, Value=abc, cause=reason=FailToGetValue, Name=foo")
+	assert.Equal(t, re.Error(), "{reason=InvalidValue, Value=abc, cause={reason=FailToGetValue, Name=foo}}")
 	assert.Equal(t, re.FileName(), "reasoned-error_test.go")
 	assert.Equal(t, re.LineNumber(), 107)
 
@@ -137,7 +137,7 @@ func TestBy_causeIsAlsoReasonedError(t *testing.T) {
 func TestOk(t *testing.T) {
 	re := reasonederror.Ok
 
-	assert.Equal(t, re.Error(), "reason=NoError")
+	assert.Equal(t, re.Error(), "{reason=NoError}")
 	assert.Equal(t, re.FileName(), "")
 	assert.Equal(t, re.LineNumber(), 0)
 


### PR DESCRIPTION
### Changes

- [feat: process #Situation and #SituationValue hierarchically](https://github.com/sttk-go/reasonederror/commit/c829c95dec3853223ac8c53750269708c228b650)

    By this modification, a return map of `#Situation` method becomes to contains parameters of `.cause`, and `#SituationValue` becomes enable to return a parameter of `.cause` which has a specified name.

- [update: rounded #Error output with curly brackets](https://github.com/sttk-go/reasonederror/commit/8282af2adc4d04d63de3b156fd023bddb97fd7b1)

    By this modification, a return string of `#Error` method is rounded with curly brackets `{}`, and become more clear when `.cause` is an `ReasonedError`.